### PR TITLE
Fix build on kernel versions 2.6.36 to 3.5.0

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -1545,7 +1545,11 @@ static void exfat_evict_inode(struct inode *inode)
 		//mark_inode_dirty(inode);
 	}
 	invalidate_inode_buffers(inode);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0)
 	clear_inode(inode);
+#else
+	end_writeback(inode);
+#endif
 	exfat_detach(inode);
 /*
 	struct exfat_sb_info *sbi = EXFAT_SB(inode->i_sb);


### PR DESCRIPTION
clear_inode() was renamed to end_writeback() in kernel version 2.6.36. It was then renamed back to clear_inode in version 3.5.0. This commit fixes builds on those kernels which also happen to be used by a large majority of android devices at present.

I have tested this on 3.4.0 and 3.5.0.
