### PR TITLE
Port to Linux 3.11

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -293,7 +293,7 @@ static int exfat_readdir(struct file *filp, struct dir_context *ctx)
 static int exfat_readdir(struct file *filp, void *dirent, filldir_t filldir)
 #endif
 {
-	struct inode *inode = filp->f_path.dentry->d_inode;
+	struct inode *inode = file_inode(d_inode);
 	struct super_block *sb = inode->i_sb;
 	struct exfat_sb_info *sbi = EXFAT_SB(sb);
 	FS_INFO_T *p_fs = &(sbi->fs_info);


### PR DESCRIPTION
Linux 3.11 changed the arguments of exfat_readdir(), port it like it was done with fatfs.

Tested with Linux 3.11-rc7
