### PR TITLE
port to Linux 3.13 (linux-next)

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -1425,9 +1425,14 @@ static int exfat_write_end(struct file *file, struct address_space *mapping,
 	return err;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0)
+static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb, struct iov_iter *iter,
+						loff_t offset)
+#else
 static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb,
 					   const struct iovec *iov,
 					   loff_t offset, unsigned long nr_segs)
+#endif
 {
 	struct inode *inode = iocb->ki_filp->f_mapping->host;
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,34)
@@ -1436,12 +1441,21 @@ static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb,
 	ssize_t ret;
 
 	if (rw == WRITE) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0)
+		if (EXFAT_I(inode)->mmu_private < (offset + iov_iter_count(iter)))
+#else
 		if (EXFAT_I(inode)->mmu_private < (offset + iov_length(iov, nr_segs)))
+#endif
 			return 0;
 	}
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,00)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0)
+	ret = blockdev_direct_IO(rw, iocb, inode, iter,
+					offset, exfat_get_block);
+#else
 	ret = blockdev_direct_IO(rw, iocb, inode, iov,
 					offset, nr_segs, exfat_get_block);
+#endif
 #else
         ret = blockdev_direct_IO(rw, iocb, inode, inode->i_sb->s_bdev, iov,
 					offset, nr_segs, exfat_get_block, NULL);
@@ -1449,7 +1463,11 @@ static ssize_t exfat_direct_IO(int rw, struct kiocb *iocb,
 
 #if LINUX_VERSION_CODE > KERNEL_VERSION(2,6,34)
 	if ((ret < 0) && (rw & WRITE))
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,13,0)
+		exfat_write_failed(mapping, offset+iov_iter_count(iter));
+#else
 		exfat_write_failed(mapping, offset+iov_length(iov, nr_segs));
+#endif
 #endif
 	return ret;
 }


### PR DESCRIPTION
Convert direct_IO to use iov_iter so it will work with Linux-next (and therefore Linux 3.13)

https://git.kernel.org/cgit/linux/kernel/git/next/linux-next.git/commit/?id=1359825cb7354b938e3c2a83ae7fad6ea911354d
