### PR TITLE
Don't always show debug messages

### DIFF
--- a/exfat_core.h
+++ b/exfat_core.h
@@ -194,7 +194,7 @@
 #define UTBL_ROW_COUNT (1<<LOW_INDEX_BIT)
 #define UTBL_COL_COUNT (1<<HIGH_INDEX_BIT)
 
-#ifdef CONFIG_EXFAT_DEBUG_MSG
+#if CONFIG_EXFAT_DEBUG_MSG
 #define DPRINTK(...)			\
 	do {								\
 		printk("[EXFAT] " __VA_ARGS__);	\


### PR DESCRIPTION
CONFIG_EXFAT_DEBUG_MSG is always defined (either by Kconfig if on, or
exfat_config.h since 89d7aab6) so currently debugging messages are
always on.
