### PR TITLE
Since mainline v3.10 d_hash and d_compare

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -336,15 +336,23 @@ static unsigned int exfat_striptail_len(const struct qstr *qstr)
 	return __exfat_striptail_len(qstr->len, qstr->name);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+static int exfat_d_hash(const struct dentry *dentry, struct qstr *qstr)
+#else
 static int exfat_d_hash(const struct dentry *dentry, const struct inode *inode,
 		struct qstr *qstr)
+#endif
 {
 	qstr->hash = full_name_hash(qstr->name, exfat_striptail_len(qstr));
 	return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+static int exfat_d_hashi(const struct dentry *dentry, struct qstr *qstr)
+#else
 static int exfat_d_hashi(const struct dentry *dentry, const struct inode *inode,
 		struct qstr *qstr)
+#endif
 {
 	struct nls_table *t = EXFAT_SB(dentry->d_sb)->nls_io;
 	const unsigned char *name;
@@ -362,9 +370,14 @@ static int exfat_d_hashi(const struct dentry *dentry, const struct inode *inode,
 	return 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+static int exfat_cmpi(const struct dentry *parent, const struct dentry *dentry,
+                unsigned int len, const char *str, const struct qstr *name)
+#else
 static int exfat_cmpi(const struct dentry *parent, const struct inode *pinode,
-		const struct dentry *dentry, const struct inode *inode,
-		unsigned int len, const char *str, const struct qstr *name)
+                const struct dentry *dentry, const struct inode *inode,
+                unsigned int len, const char *str, const struct qstr *name)
+#endif
 {
 	struct nls_table *t = EXFAT_SB(parent->d_sb)->nls_io;
 	unsigned int alen, blen;
@@ -378,9 +391,14 @@ static int exfat_cmpi(const struct dentry *parent, const struct inode *pinode,
 	return 1;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,10,0)
+static int exfat_cmp(const struct dentry *parent, const struct dentry *dentry,
+               unsigned int len, const char *str, const struct qstr *name)
+#else
 static int exfat_cmp(const struct dentry *parent, const struct inode *pinode,
-		const struct dentry *dentry, const struct inode *inode,
-		unsigned int len, const char *str, const struct qstr *name)
+               const struct dentry *dentry, const struct inode *inode,
+               unsigned int len, const char *str, const struct qstr *name)
+#endif
 {
 	unsigned int alen, blen;
 


### PR DESCRIPTION
do not require inode to be passed as a argument
for details, see mainline commit da53be12bbb4fabbe2e9f6f908de0cf478b5161d
