### PR TITLE
fix compilation for <3.3 kernels

### DIFF
--- a/exfat_nls.c
+++ b/exfat_nls.c
@@ -353,7 +353,11 @@ void nls_cstring_to_uniname(struct super_block *sb, UNI_NAME_T *p_uniname, u8 *p
 		lossy = TRUE;
 
 	if (nls == NULL) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0)
+		i = utf8s_to_utf16s(p_cstring, MAX_NAME_LENGTH, uniname);
+#else
 		i = utf8s_to_utf16s(p_cstring, MAX_NAME_LENGTH, UTF16_HOST_ENDIAN, uniname, MAX_NAME_LENGTH);
+#endif
 		for (j = 0; j < i; j++)
 			SET16_A(upname + j * 2, nls_upper(sb, uniname[j]));
 		uniname[i] = '\0';


### PR DESCRIPTION
utf8s_to_utf16s has changed as per this commit: https://github.com/torvalds/linux/commit/0720a06a7518c9d0c0125bd5d1f3b6264c55c3dd
