### PR TITLE
 fix exfat_super.c

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -573,7 +573,11 @@ static long exfat_generic_ioctl(struct file *filp,
 #endif
 {
 #if !(LINUX_VERSION_CODE < KERNEL_VERSION(2,6,36))
-	struct inode *inode = filp->f_dentry->d_inode;
+    #if !(LINUX_VERSION_CODE < KERNEL_VERSION(3,18,3))
+		  struct inode *inode = filp->f_path.dentry->d_inode;
+    #else
+		  struct inode *inode = filp->f_dentry->d_inode;
+	#endif
 #endif
 #ifdef CONFIG_EXFAT_KERNEL_DEBUG
 	unsigned int flags;


### PR DESCRIPTION
 - newer fs.h missing "f_dentry" in struct file.
   use "f_path.dentry" instead of "f_dentry".