### PR TITLE
exfat_super.c: use strncasecmp instead of strnicmp

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -386,7 +386,7 @@ static int exfat_cmpi(const struct dentry *parent, const struct inode *pinode,
 	blen = __exfat_striptail_len(len, str);
 	if (alen == blen) {
 		if (t == NULL) {
-			if (strnicmp(name->name, str, alen) == 0)
+			if (strncasecmp(name->name, str, alen) == 0)
 				return 0;
 		} else if (nls_strnicmp(t, name->name, str, alen) == 0)
 			return 0;


### PR DESCRIPTION
There are two functions, `strnicmp` and `strncasecmp` do the
same thing. In Linux 3.18, `strnicmp` was renamed to `strncasecmp`,
and the original function became a wrapper to it. In Linux 4.0,
`strnicmp` was removed.

There is a problem, `strncasecmp` in previous kernels doesn't handle
`len == 0` properly, and this is the reason of the co-existence of two functions.
In my opinion, both `alen` and `blen`can't be zero, it should not break the code
on previous kernels. So I just simply rename the function call, without check if it
is zero to avoid dead code. But I'm not very sure, please verity it.