### PR TITLE
Don't lookup dos name entries for exfat

### DIFF
--- a/exfat_core.c
+++ b/exfat_core.c
@@ -1171,7 +1171,7 @@ s32 ffsGetStat(struct inode *inode, DIR_ENTRY_T *info)
 	/* XXX this is very bad for exfat cuz name is already included in es.
 	 API should be revised */
 	p_fs->fs_func->get_uni_name_from_ext_entry(sb, &(fid->dir), fid->entry, uni_name.name);
-	if (*(uni_name.name) == 0x0)
+	if (*(uni_name.name) == 0x0 && p_fs->vol_type != EXFAT)
 		get_uni_name_from_dos_entry(sb, (DOS_DENTRY_T *) ep, &uni_name, 0x1);
 	nls_uniname_to_cstring(sb, info->Name, &uni_name);
 
@@ -1556,7 +1556,7 @@ s32 ffsReadDir(struct inode *inode, DIR_ENTRY_T *dir_entry)
 
 			*(uni_name.name) = 0x0;
 			p_fs->fs_func->get_uni_name_from_ext_entry(sb, &dir, dentry, uni_name.name);
-			if (*(uni_name.name) == 0x0)
+			if (*(uni_name.name) == 0x0 && p_fs->vol_type != EXFAT)
 				get_uni_name_from_dos_entry(sb, (DOS_DENTRY_T *) ep, &uni_name, 0x1);
 			nls_uniname_to_cstring(sb, dir_entry->Name, &uni_name);
 			buf_unlock(sb, sector);


### PR DESCRIPTION
We can't use get_uni_name_from_dos_entry() on EXFAT because later in
nls_dosname_to_uniname() we'd access the EXFAT_SB(sb)->nls_disk which is only
valid for FAT16/32 filesystems, and finally in convert_ch_to_uni()
nls->char2uni() throws a null pointer exception.

This avoids the following kernel oops (note that the epc is not quite right):

[  261.780000] CPU 0 Unable to handle kernel paging request at virtual address 0000000c, epc == 81b2d25c, ra == 81b2d890
[  261.780000] Oops[#1]:
[  261.780000] CPU: 0 PID: 1354 Comm: ls Not tainted 3.18.11 #26
[  261.780000] task: 81905d10 ti: 8172c000 task.ti: 8172c000
[  261.780000] $ 0   : 00000000 0000002e 00000085 ffffff85
[  261.780000] $ 4   : 8172d820 8172d888 8172d820 00000000
[  261.780000] $ 8   : 8172d853 00000020 00000000 8171fd80
[  261.780000] $12   : 8171fdc0 8172def0 00000000 8171fe00
[  261.780000] $16   : 8172d888 00000000 00000000 8172da86
[  261.780000] $20   : 817d3fa0 00000400 000003fd 00001ffd
[  261.780000] $24   : 00000018 00007fa0
[  261.780000] $28   : 8172c000 8172d7f0 0000000a 81b2d890
[  261.780000] Hi    : 00000007
[  261.780000] Lo    : 12cd5480
[  261.780000] epc   : 81b2d25c exfat_bitmap_clear+0x6c/0x104 [exfat]
[  261.780000]     Not tainted
[  261.780000] ra    : 81b2d890 nls_dosname_to_uniname+0x138/0x164 [exfat]
[  261.780000] Status: 1100e403 KERNEL EXL IE
[  261.780000] Cause : 40800008
[  261.780000] BadVA : 0000000c
[  261.780000] PrId  : 0001964c (MIPS 24KEc)
[  261.780000] Modules linked in: iptable_nat nf_nat_ipv4 nf_conntrack_ipv4 ipt_REJECT ipt_MASQUERADE xt_time xt_tcpudp xt_sn
[  261.780000] Process ls (pid: 1354, threadinfo=8172c000, task=81905d10, tls=777d3440)
[  261.780000] Stack : 007cadc0 81b21c08 00019b00 00000200 8172d888 00000000 00000000 81b2d890
          80dc8410 81b214fc 8172db30 814a03c0 6f5d0385 9b65b52e 817d3f00 00000400
          000003fd 8172d888 81b7ec00 80cc0000 81b7ec00 81b22394 00000100 8171fdc0
          8172d858 8171fe40 6f5d0385 00000020 399b45b5 814a03c0 80cc0000 8172db30
          814a03c0 81b22ab4 000f0011 00220004 00400000 fffff113 004d0000 005f0047
          ...
[  261.780000] Call Trace:
[  261.780000] [<81b2d25c>] exfat_bitmap_clear+0x6c/0x104 [exfat]
[  261.780000] [<81b2d890>] nls_dosname_to_uniname+0x138/0x164 [exfat]
[  261.780000]
[  261.780000]
Code: a4a20000  086cb4b7  24020001 <8e22000c> 24050006  02003021  0040f809  00e09021  0441001b
[  262.400000] ---[ end trace d76b48c9f51eb897 ]---
0
Segmentation fault