### PR TITLE
Fix compilation error for kernel version codes < 3.0.0

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -294,14 +294,14 @@ static int exfat_revalidate_ci(struct dentry *dentry, struct nameidata *nd)
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,00)
 	if (flags & LOOKUP_RCU)
 		return -ECHILD;
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,00)
+#else
 	unsigned int flags;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,0,00)
 	if (nd && nd->flags & LOOKUP_RCU)
 		return -ECHILD;
+#endif
 
-	flags = nd ? nd->flags : 0;
-#else
 	flags = nd ? nd->flags : 0;
 #endif
 


### PR DESCRIPTION
This was caused by the flags variable being declared only if the version
is >= 3.0.0 and < 3.7.0 (where it is no longer need)