### PR TITLE
Fixed compilation for linux kernel < 3.3.0

### DIFF
--- a/exfat_nls.c
+++ b/exfat_nls.c
@@ -353,7 +353,7 @@ void nls_cstring_to_uniname(struct super_block *sb, UNI_NAME_T *p_uniname, u8 *p
 		lossy = TRUE;
 
 	if (nls == NULL) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3,3,0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,0,101)
 		i = utf8s_to_utf16s(p_cstring, MAX_NAME_LENGTH, uniname);
 #else
 		i = utf8s_to_utf16s(p_cstring, MAX_NAME_LENGTH, UTF16_HOST_ENDIAN, uniname, MAX_NAME_LENGTH);


### PR DESCRIPTION
After kernel source review, i find out that new syntax of function of function utf8s_to_utf16s from fs/nls/nls_base.c first time appear in version 3.0.101, please see
http://tomoyo.osdn.jp/cgi-bin/lxr/source/fs/nls/nls_base.c?v=linux-3.0.101