### PR TITLE
core: Fix -Wmisleading-indentation in ffsMountVol()

### DIFF
--- a/exfat_core.c
+++ b/exfat_core.c
@@ -183,7 +183,7 @@ s32 ffsMountVol(struct super_block *sb)
 	if (sector_read(sb, 0, &tmp_bh, 1) != FFS_SUCCESS)
 		return FFS_MEDIAERR;
 
-		p_fs->PBR_sector = 0;
+	p_fs->PBR_sector = 0;
 
 	p_pbr = (PBR_SECTOR_T *) tmp_bh->b_data;
 


### PR DESCRIPTION
Newer toolchains start to pay attention to these formatting issues, which may be treated as errors:
```
external/exfat-nofuse/exfat_core.c:183:2: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  if (sector_read(sb, 0, &tmp_bh, 1) != FFS_SUCCESS)
  ^~
external/exfat-nofuse/exfat_core.c:186:3: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
   p_fs->PBR_sector = 0;
```
