### PR TITLE
Fix leak for symbolic link in exfat_lookup

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -829,7 +829,7 @@ static struct dentry *exfat_lookup(struct inode *dir, struct dentry *dentry,
 	}
 
 	i_mode = inode->i_mode;
-	if (S_ISLNK(i_mode)) {
+	if (S_ISLNK(i_mode) && !EXFAT_I(inode)->target) {
 		EXFAT_I(inode)->target = kmalloc(i_size_read(inode)+1, GFP_KERNEL);
 		if (!EXFAT_I(inode)->target) {
 			err = -ENOMEM;


### PR DESCRIPTION
While exfat_lookup() for symbolic file, we Should not alloc memory
to EXFAT_I(inode)->target since the corredspoding exfat inode info
is still is in memory and EXFAT_I(inode)->target has not released
yet. If we do so, memory leak would happen. Therefore we only alloc
it if not null.

Reviewed-by: Ethan Wu <ethanwu@synology.com>
Signed-off-by: Chung-Chiang Cheng <cccheng@synology.com>