### PR TITLE
exfat_super: Update for kernel 4.11 compatibility

### DIFF
--- a/exfat_super.c
+++ b/exfat_super.c
@@ -1363,9 +1363,16 @@ static int exfat_setattr(struct dentry *dentry, struct iattr *attr)
 	return error;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
+static int exfat_getattr(const struct path *path, struct kstat *stat,
+			 u32 request_mask, unsigned int flags)
+{
+	struct inode *inode = path->dentry->d_inode;
+#else
 static int exfat_getattr(struct vfsmount *mnt, struct dentry *dentry, struct kstat *stat)
 {
 	struct inode *inode = dentry->d_inode;
+#endif
 
 	DPRINTK("exfat_getattr entered\n");
 


### PR DESCRIPTION
In Linux kernel 4.11, the prototype of getattr function changed.

Use the new prototype and change inode acquring code, when kernel
version > 4.11.

Signed-off-by: Icenowy Zheng <icenowy@aosc.io>