### PR TITLE
dkms: Support building for non-current kernel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ EXTRA_FLAGS += -I$(PWD)
 # any valid path to the directory in which the target kernel's source is located
 # can be provided on the command line.
 #
-KDIR	:= /lib/modules/$(shell uname -r)/build
-MDIR	:= /lib/modules/$(shell uname -r)
+KDIR	?= /lib/modules/$(shell uname -r)/build
+MDIR	?= /lib/modules/$(shell uname -r)
 PWD	:= $(shell pwd)
 KREL	:= $(shell cd ${KDIR} && make -s kernelrelease)
 PWD	:= $(shell pwd)

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="exfat"
 PACKAGE_VERSION="1.2.8"
-MAKE="KDIR=/lib/modules/$kernelver/build make"
+MAKE="KDIR=/lib/modules/$kernelver/build MDIR=/lib/modules/$kernelver make"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="exfat"
 AUTOINSTALL="yes"


### PR DESCRIPTION
Currently, the dkms build will build the module against the running kernel, even if it's requested for some other kernel - resulting in a module that doesn't work at runtime.