### PR TITLE
exfat: Stop using CURRENT_TIME_SEC

### DIFF
--- a/exfat_oal.c
+++ b/exfat_oal.c
@@ -128,10 +128,16 @@ static time_t accum_days_in_year[] = {
 
 TIMESTAMP_T *tm_current(TIMESTAMP_T *tp)
 {
-	struct timespec ts = CURRENT_TIME_SEC;
-	time_t second = ts.tv_sec;
-	time_t day, leap_day, month, year;
+	struct timespec ts;
+	time_t second, day, leap_day, month, year;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
+	ts = CURRENT_TIME_SEC;
+#else
+	ktime_get_real_ts(&ts);
+#endif
+
+	second = ts.tv_sec;
 	second -= sys_tz.tz_minuteswest * SECS_PER_MIN;
 
 	/* Jan 1 GMT 00:00:00 1980. But what about another time zone? */


### PR DESCRIPTION
 * This is going away in 4.12, replace all instances with
   ktime_get_real_ts64 and timespec64.