### PR TITLE
Makefile: remove KREL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ EXTRA_FLAGS += -I$(PWD)
 KDIR	?= /lib/modules/$(shell uname -r)/build
 MDIR	?= /lib/modules/$(shell uname -r)
 PWD	:= $(shell pwd)
-KREL	:= $(shell cd ${KDIR} && make -s kernelrelease)
 PWD	:= $(shell pwd)
 
 export CONFIG_EXFAT_FS := m


### PR DESCRIPTION
The KREL macro defined in the Makefile isn't used, although the "make -s
kernelrelease" command that is run as part of its definition causes a
non-fatal build error when the kernel is built outside its source
directory, for example, in distros such as Debian and Ubuntu:

/usr/src/linux-headers-4.9.0-3-common/scripts/Makefile.build:44: /usr/src/linux-headers-4.9.0-3-common/scripts/basic/Makefile: No such file or directory
make[4]: *** No rule to make target '/usr/src/linux-headers-4.9.0-3-common/scripts/basic/Makefile'.  Stop.
make[3]: *** [scripts_basic] Error 2

The Makefile carries on to build the module after this error.  Just
remove the KREL macro to avoid it in the first place.