### PR TITLE
Fix for kernel 5.6

### DIFF
--- a/exfat_core.c
+++ b/exfat_core.c
@@ -1757,8 +1757,8 @@ void fs_error(struct super_block *sb)
 
 	if (opts->errors == EXFAT_ERRORS_PANIC)
 		panic("[EXFAT] Filesystem panic from previous error\n");
-	else if ((opts->errors == EXFAT_ERRORS_RO) && !(sb->s_flags & MS_RDONLY)) {
-		sb->s_flags |= MS_RDONLY;
+	else if ((opts->errors == EXFAT_ERRORS_RO) && !(sb->s_flags & SB_RDONLY)) {
+		sb->s_flags |= SB_RDONLY;
 		printk(KERN_ERR "[EXFAT] Filesystem has been set read-only\n");
 	}
 }

--- a/exfat_oal.c
+++ b/exfat_oal.c
@@ -128,13 +128,13 @@ static time_t accum_days_in_year[] = {
 
 TIMESTAMP_T *tm_current(TIMESTAMP_T *tp)
 {
-	struct timespec ts;
+	struct timespec64 ts;
 	time_t second, day, leap_day, month, year;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
 	ts = CURRENT_TIME_SEC;
 #else
-	ktime_get_real_ts(&ts);
+	ktime_get_real_ts64(&ts);
 #endif
 
 	second = ts.tv_sec;

--- a/exfat_oal.c
+++ b/exfat_oal.c
@@ -121,7 +121,7 @@ extern struct timezone sys_tz;
 	} while (0)
 
 /* Linear day numbers of the respective 1sts in non-leap years. */
-static time_t accum_days_in_year[] = {
+static ktime_t accum_days_in_year[] = {
 	/* Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct  Nov  Dec */
 	0,   0,  31,  59,  90, 120, 151, 181, 212, 243, 273, 304, 334, 0, 0, 0,
 };
@@ -129,7 +129,7 @@ static time_t accum_days_in_year[] = {
 TIMESTAMP_T *tm_current(TIMESTAMP_T *tp)
 {
 	struct timespec64 ts;
-	time_t second, day, leap_day, month, year;
+	ktime_t second, day, leap_day, month, year;
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,8,0)
 	ts = CURRENT_TIME_SEC;

--- a/exfat_super.c
+++ b/exfat_super.c
@@ -147,7 +147,7 @@ static time_t accum_days_in_year[] = {
 static void _exfat_truncate(struct inode *inode, loff_t old_size);
 
 /* Convert a FAT time/date pair to a UNIX date (seconds since 1 1 70). */
-void exfat_time_fat2unix(struct exfat_sb_info *sbi, struct timespec *ts,
+void exfat_time_fat2unix(struct exfat_sb_info *sbi, struct timespec64 *ts,
 						 DATE_TIME_T *tp)
 {
 	time_t year = tp->Year;
@@ -166,7 +166,7 @@ void exfat_time_fat2unix(struct exfat_sb_info *sbi, struct timespec *ts,
 }
 
 /* Convert linear UNIX date to a FAT time/date pair. */
-void exfat_time_unix2fat(struct exfat_sb_info *sbi, struct timespec *ts,
+void exfat_time_unix2fat(struct exfat_sb_info *sbi, struct timespec64 *ts,
 						 DATE_TIME_T *tp)
 {
 	time_t second = ts->tv_sec;
@@ -2080,7 +2080,7 @@ static void exfat_write_super(struct super_block *sb)
 
 	__set_sb_clean(sb);
 
-	if (!(sb->s_flags & MS_RDONLY))
+	if (!(sb->s_flags & SB_RDONLY))
 		FsSyncVol(sb, 1);
 
 	__unlock_super(sb);
@@ -2136,7 +2136,7 @@ static int exfat_statfs(struct dentry *dentry, struct kstatfs *buf)
 
 static int exfat_remount(struct super_block *sb, int *flags, char *data)
 {
-	*flags |= MS_NODIRATIME;
+	*flags |= SB_NODIRATIME;
 	return 0;
 }
 
@@ -2489,7 +2489,7 @@ static int exfat_fill_super(struct super_block *sb, void *data, int silent)
 	mutex_init(&sbi->s_lock);
 #endif
 	sb->s_fs_info = sbi;
-	sb->s_flags |= MS_NODIRATIME;
+	sb->s_flags |= SB_NODIRATIME;
 	sb->s_magic = EXFAT_SUPER_MAGIC;
 	sb->s_op = &exfat_sops;
 	sb->s_export_op = &exfat_export_ops;

--- a/exfat_super.c
+++ b/exfat_super.c
@@ -139,7 +139,7 @@ extern struct timezone sys_tz;
 	} while (0)
 
 /* Linear day numbers of the respective 1sts in non-leap years. */
-static time_t accum_days_in_year[] = {
+static ktime_t accum_days_in_year[] = {
 	/* Jan  Feb  Mar  Apr  May  Jun  Jul  Aug  Sep  Oct  Nov  Dec */
 	0,   0,  31,  59,  90, 120, 151, 181, 212, 243, 273, 304, 334, 0, 0, 0,
 };
@@ -150,8 +150,8 @@ static void _exfat_truncate(struct inode *inode, loff_t old_size);
 void exfat_time_fat2unix(struct exfat_sb_info *sbi, struct timespec64 *ts,
 						 DATE_TIME_T *tp)
 {
-	time_t year = tp->Year;
-	time_t ld;
+	ktime_t year = tp->Year;
+	ktime_t ld;
 
 	MAKE_LEAP_YEAR(ld, year);
 
@@ -169,9 +169,9 @@ void exfat_time_fat2unix(struct exfat_sb_info *sbi, struct timespec64 *ts,
 void exfat_time_unix2fat(struct exfat_sb_info *sbi, struct timespec64 *ts,
 						 DATE_TIME_T *tp)
 {
-	time_t second = ts->tv_sec;
-	time_t day, month, year;
-	time_t ld;
+	ktime_t second = ts->tv_sec;
+	ktime_t day, month, year;
+	ktime_t ld;
 
 	second -= sys_tz.tz_minuteswest * SECS_PER_MIN;
 


### PR DESCRIPTION
Changes MS_* flags to SB_* flags.
Changes timespec struct to timespec64.
Changes ktime_get_real_ts to ktime_get_real_ts64.
Changes time_t struct to ktime_t
Builds on 5.6.0 at time of writing.